### PR TITLE
Make Devlog available to feed readers

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -14,7 +14,7 @@ on:
 
 
 env:
-  ZOLA_VERSION: 0.18.0
+  ZOLA_VERSION: 0.19.2
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Build website"
-        uses: shalzz/zola-deploy-action@master
+        uses: shalzz/zola-deploy-action@v0.19.2
         env:
           BUILD_DIR: website
           TOKEN: fake-token

--- a/website/config.toml
+++ b/website/config.toml
@@ -14,6 +14,14 @@ compile_sass = false
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
 
+# When set to "true", a feed is automatically generated.
+generate_feeds = true
+
+# The filename to use for the feed. Used as the template filename, too.
+# Defaults to "atom.xml", which has a built-in template that renders an Atom 1.0 feed.
+# There is also a built-in template "rss.xml" that renders an RSS 2.0 feed.
+feed_filenames = ["atom.xml"]
+
 #taxonomies = [
 #    {name = "tags", paginate_by = 5, feed = true},
 #    {name = "categories", paginate_by = 5, feed = true},

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -6,7 +6,6 @@
 
 title = "API Docs"
 description = "Latest documentation of the public API"
-date = 2000-01-01
 template = "docs.html"
 page_template = "page.html"
 sort_by = "date"

--- a/website/templates/devlog-page.html
+++ b/website/templates/devlog-page.html
@@ -7,6 +7,10 @@
 
 {% extends "layout.html" %}
 
+{% block page_head %}
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
+{% endblock %}
+
 {% block content %}
 <div class="flex items-center flex-col mt-10">
   <div class="markdown-content">

--- a/website/templates/devlog.html
+++ b/website/templates/devlog.html
@@ -7,6 +7,10 @@
 
 {% extends "layout.html" %}
 
+{% block page_head %}
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
+{% endblock %}
+
 {% block content %}
 <div class="flex items-center flex-col mt-10">
   <!-- Content -->

--- a/website/templates/layout.html
+++ b/website/templates/layout.html
@@ -91,6 +91,9 @@
       <meta name="twitter:description" content="{{ c_page_summary }}">
       <meta name="twitter:image" content="{{ c_page_image | safe }}">
 
+      {% block page_head %}
+      {% endblock%}
+
     </head>
   <body class="body-background dark:body-background flex flex-col h-screen justify-between">
   <!---------------------------------------------------------->


### PR DESCRIPTION
Enabling the atom feed and linking it inside the devlog pages makes it possible for feed readers to subscribe to the devlog.