### PR TITLE
Only generate Atom feed for devlog

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -14,8 +14,8 @@ compile_sass = false
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
 
-# When set to "true", a feed is automatically generated.
-generate_feeds = true
+# We don't want to generate a site wide feed, but only one for the devlog.
+generate_feeds = false
 
 # The filename to use for the feed. Used as the template filename, too.
 # Defaults to "atom.xml", which has a built-in template that renders an Atom 1.0 feed.

--- a/website/content/dev/_index.md
+++ b/website/content/dev/_index.md
@@ -9,6 +9,7 @@ description = "Recurring posts on godot-rust development"
 template = "devlog.html"
 page_template = "devlog-page.html"
 sort_by = "date"
+generate_feeds = true
 # Pagination should probably be implemented at some point, for now "disable" it
 paginate_by = 1000
 +++

--- a/website/templates/devlog.html
+++ b/website/templates/devlog.html
@@ -7,9 +7,6 @@
 
 {% extends "layout.html" %}
 
-{% block page_head %}
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
-{% endblock %}
 
 {% block content %}
 <div class="flex items-center flex-col mt-10">

--- a/website/templates/layout.html
+++ b/website/templates/layout.html
@@ -91,9 +91,9 @@
       <meta name="twitter:description" content="{{ c_page_summary }}">
       <meta name="twitter:image" content="{{ c_page_image | safe }}">
 
-      {% block page_head %}
-      {% endblock%}
-
+      {% if section and section.generate_feeds %}
+        <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ current_path | safe }}atom.xml">
+      {% endif %}
     </head>
   <body class="body-background dark:body-background flex flex-col h-screen justify-between">
   <!---------------------------------------------------------->


### PR DESCRIPTION
The first attempt at setting up the atom feed was missing the fact that `docs` pages are included in CI. We can set the feed generation to only be enabled for the `/content/dev` section .