### PR TITLE
Fix typo in 0.4 devlog: class dispatching.

### DIFF
--- a/website/content/dev/2025-09-29-september-2025-update/index.md
+++ b/website/content/dev/2025-09-29-september-2025-update/index.md
@@ -211,12 +211,12 @@ No more tedious `try_cast()` cascades for explicit dynamic dispatch. The [`match
 Thanks to sylbeth's work, the macro supports mutable bindings ([#1242]), optional fallback branches ([#1246]), and discard patterns ([#1252]):
 
 ```rust
-let simple_dispatch: i32 = match_class!(event, {
+let simple_dispatch: i32 = match_class! { event,
     button @ InputEventMouseButton => 1,
     motion @ InputEventMouseMotion => 2,
     action @ InputEventAction => 3,
     _ => 0,  // Fallback.
-});
+};
 ```
 
 ### Generic packed arrays


### PR DESCRIPTION
_[Edit bromeon]:_
Closes https://github.com/godot-rust/gdext/issues/1359

It should be:

```rs
let simple_dispatch: i32 = match_class! { event,
    button @ InputEventMouseButton => 1,
    motion @ InputEventMouseMotion => 2,
    action @ InputEventAction => 3,
    _ => 0,  // Fallback.
};
```

Instead of 

```rs
let simple_dispatch: i32 = match_class!(event, {
    button @ InputEventMouseButton => 1,
    motion @ InputEventMouseMotion => 2,
    action @ InputEventAction => 3,
    _ => 0,  // Fallback.
});
```